### PR TITLE
Add Tokyo Night gradient theme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Apple Silicon processors don't provide an easy way to see live power consumption
 - 💾 RAM / Swap usage
 - 📈 Historical charts + avg / max values
 - 🌡️ Average CPU / GPU temperature
-- 🎨 Switchable colors (6 variants)
+- 🎨 Switchable colors (6 variants) plus Tokyo Night theme
 - 🪟 Can be rendered in a small window
 - 🦀 Written in Rust
 
@@ -81,11 +81,12 @@ Commands:
 
 Options:
   -i, --interval <INTERVAL>  Update interval in milliseconds [default: 1000]
+  --theme <THEME>           Set theme (default or tokyo-night)
   -h, --help                 Print help
   -V, --version              Print version
 
 Controls:
-  c - change color
+  c - change theme
   v - switch charts view: gauge / sparkline
   q - quit
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::theme::{TOKYO_NIGHT, Theme, ThemePalette};
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 use serde_inline_default::serde_inline_default;
@@ -16,6 +17,9 @@ pub enum ViewType {
 pub struct Config {
   #[serde_inline_default(ViewType::Sparkline)]
   pub view_type: ViewType,
+
+  #[serde_inline_default(Theme::Default)]
+  pub theme: Theme,
 
   #[serde_inline_default(COLORS_OPTIONS[0])]
   pub color: Color,
@@ -68,12 +72,41 @@ impl Config {
     }
   }
 
-  pub fn next_color(&mut self) {
-    self.color = match COLORS_OPTIONS.iter().position(|&c| c == self.color) {
-      Some(idx) => COLORS_OPTIONS[(idx + 1) % COLORS_OPTIONS.len()],
-      None => COLORS_OPTIONS[0],
-    };
+  pub fn next_theme(&mut self) {
+    match self.theme {
+      Theme::Default => {
+        if let Some(idx) = COLORS_OPTIONS.iter().position(|&c| c == self.color) {
+          if idx + 1 < COLORS_OPTIONS.len() {
+            self.color = COLORS_OPTIONS[idx + 1];
+          } else {
+            self.theme = Theme::TokyoNight;
+          }
+        } else {
+          self.color = COLORS_OPTIONS[0];
+        }
+      }
+      Theme::TokyoNight => {
+        self.theme = Theme::Default;
+        self.color = COLORS_OPTIONS[0];
+      }
+    }
     self.save();
+  }
+
+  pub fn palette(&self) -> ThemePalette {
+    match self.theme {
+      Theme::Default => ThemePalette {
+        border: self.color,
+        text: Color::Reset,
+        start: self.color,
+        mid: self.color,
+        end: self.color,
+        start256: self.color,
+        mid256: self.color,
+        end256: self.color,
+      },
+      Theme::TokyoNight => TOKYO_NIGHT,
+    }
   }
 
   pub fn next_view_type(&mut self) {

--- a/src/gradient_gauge.rs
+++ b/src/gradient_gauge.rs
@@ -1,0 +1,70 @@
+use ratatui::{
+  prelude::*,
+  symbols,
+  widgets::{Widget, block::Block},
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct GradientGauge<'a> {
+  block: Option<Block<'a>>,
+  ratio: f64,
+  style: Style,
+  start: Color,
+  mid: Color,
+  end: Color,
+}
+
+impl<'a> GradientGauge<'a> {
+  pub fn block(mut self, block: Block<'a>) -> Self {
+    self.block = Some(block);
+    self
+  }
+
+  pub fn ratio(mut self, ratio: f64) -> Self {
+    self.ratio = ratio.clamp(0.0, 1.0);
+    self
+  }
+
+  pub fn style<S: Into<Style>>(mut self, style: S) -> Self {
+    self.style = style.into();
+    self
+  }
+
+  pub fn colors(mut self, start: Color, mid: Color, end: Color) -> Self {
+    self.start = start;
+    self.mid = mid;
+    self.end = end;
+    self
+  }
+}
+
+impl Widget for GradientGauge<'_> {
+  fn render(self, area: Rect, buf: &mut Buffer) {
+    buf.set_style(area, self.style);
+    let gauge = if let Some(ref block) = self.block {
+      block.render(area, buf);
+      block.inner(area)
+    } else {
+      area
+    };
+    if gauge.is_empty() {
+      return;
+    }
+    let filled = (gauge.width as f64 * self.ratio).round() as u16;
+    let third = gauge.width.max(1) / 3;
+    for y in gauge.top()..gauge.bottom() {
+      for x in gauge.left()..gauge.right() {
+        if x - gauge.left() < filled {
+          let color = if x - gauge.left() < third {
+            self.start
+          } else if x - gauge.left() < third * 2 {
+            self.mid
+          } else {
+            self.end
+          };
+          buf[(x, y)].set_symbol(symbols::block::FULL).set_fg(color);
+        }
+      }
+    }
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 mod app;
 mod config;
 mod debug;
+mod gradient_gauge;
 mod metrics;
 mod sources;
+mod theme;
 
+use crate::theme::Theme;
 use app::App;
 use clap::{CommandFactory, Parser, Subcommand, parser::ValueSource};
 use metrics::Sampler;
@@ -34,6 +37,10 @@ struct Cli {
   /// Update interval in milliseconds
   #[arg(short, long, global = true, default_value_t = 1000)]
   interval: u32,
+
+  /// Theme to use (default or tokyo-night)
+  #[arg(long, value_enum)]
+  theme: Option<Theme>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -68,6 +75,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         Some(ValueSource::CommandLine) => Some(args.interval),
         _ => None,
       };
+
+      if let Some(ValueSource::CommandLine) = matches.value_source("theme") {
+        app.set_theme(args.theme.unwrap_or(Theme::Default));
+      }
 
       app.run_loop(msec)?;
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,58 @@
+use clap::ValueEnum;
+use ratatui::style::Color;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+pub enum Theme {
+  Default,
+  TokyoNight,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ThemePalette {
+  pub border: Color,
+  pub text: Color,
+  pub start: Color,
+  pub mid: Color,
+  pub end: Color,
+  pub start256: Color,
+  pub mid256: Color,
+  pub end256: Color,
+}
+
+const TOKYO_NIGHT_START: Color = Color::Rgb(0x9e, 0xce, 0x6a);
+const TOKYO_NIGHT_MID: Color = Color::Rgb(0xe0, 0xaf, 0x68);
+const TOKYO_NIGHT_END: Color = Color::Rgb(0xf7, 0x76, 0x8e);
+
+const TOKYO_NIGHT_START_256: Color = Color::Indexed(150);
+const TOKYO_NIGHT_MID_256: Color = Color::Indexed(180);
+const TOKYO_NIGHT_END_256: Color = Color::Indexed(211);
+
+pub const TOKYO_NIGHT: ThemePalette = ThemePalette {
+  border: Color::Rgb(0x7d, 0xcf, 0xff),
+  text: Color::Rgb(0xcf, 0xc9, 0xc2),
+  start: TOKYO_NIGHT_START,
+  mid: TOKYO_NIGHT_MID,
+  end: TOKYO_NIGHT_END,
+  start256: TOKYO_NIGHT_START_256,
+  mid256: TOKYO_NIGHT_MID_256,
+  end256: TOKYO_NIGHT_END_256,
+};
+
+fn truecolor() -> bool {
+  std::env::var("COLORTERM")
+    .map(|v| v.contains("truecolor") || v.contains("24bit"))
+    .unwrap_or(false)
+}
+
+impl ThemePalette {
+  pub fn start_color(&self) -> Color {
+    if truecolor() { self.start } else { self.start256 }
+  }
+  pub fn mid_color(&self) -> Color {
+    if truecolor() { self.mid } else { self.mid256 }
+  }
+  pub fn end_color(&self) -> Color {
+    if truecolor() { self.end } else { self.end256 }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce theme system with new Tokyo Night palette
- add GradientGauge widget for multi-color gauges
- allow `--theme` CLI flag and cycle themes with `c`
- document theme option and controls

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings` *(fails: cannot find macOS-specific libc symbols)*